### PR TITLE
Feat/private games - create

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs: # a collection of steps
 workflows:
   build-test-deploy:
     jobs:
-        - build-and-test
+      - build-and-test
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,9 @@ workflows:
   build-test-deploy:
     jobs:
       - build-and-test
-          filters:
-            branches:
-              only: main
+        filters:
+          branches:
+            only: main
       - deploy:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,11 @@ jobs: # a collection of steps
             command: curl -X GET "https://api.render.com/deploy/srv-cme3mt8l5elc73csk8v0?key=nMHgmyoZ0qU"
 workflows:
   build-test-deploy:
-    filters:
-      branches:
-        only: main
     jobs:
-      - build-and-test
+      - build-and-test:
+          filters:
+            branches:
+              only: main
       - deploy:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,10 @@ jobs: # a collection of steps
 workflows:
   build-test-deploy:
     jobs:
-      - build-and-test
+        - build-and-test
+          filters:
+            branches:
+              only: main
       - deploy:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,11 @@ jobs: # a collection of steps
             command: curl -X GET "https://api.render.com/deploy/srv-cme3mt8l5elc73csk8v0?key=nMHgmyoZ0qU"
 workflows:
   build-test-deploy:
+    filters:
+      branches:
+        only: main
     jobs:
       - build-and-test
-        filters:
-          branches:
-            only: main
       - deploy:
           requires:
             - build-and-test

--- a/JSON_CONTRACT.md
+++ b/JSON_CONTRACT.md
@@ -338,6 +338,7 @@
             "player_cap": 18,
             "status": 0,
             "start_date": "2024-02-02",
+            "close_date": "2024-06-30",
             "users": [
                           {
                   "id": "240",

--- a/app/controllers/api/v0/users/games_controller.rb
+++ b/app/controllers/api/v0/users/games_controller.rb
@@ -2,7 +2,9 @@ class Api::V0::Users::GamesController < ApplicationController
 
   def create
     admin_user = User.find(params[:id])
-    Game.create(game_params)
+    game = Game.create(game_params)
+    UserGame.create(user_id: admin_user.id, game_id: game.id, invitation: 3)
+    render json: GameSerializer.new(game)
   end
 
   private

--- a/app/controllers/api/v0/users/games_controller.rb
+++ b/app/controllers/api/v0/users/games_controller.rb
@@ -1,0 +1,13 @@
+class Api::V0::Users::GamesController < ApplicationController
+
+  def create
+    admin_user = User.find(params[:id])
+    Game.create(game_params)
+  end
+
+  private
+
+  def game_params
+    params.permit(:length_in_days, :guess_lead_time, :player_cap)
+  end
+end

--- a/app/controllers/api/v0/users/games_controller.rb
+++ b/app/controllers/api/v0/users/games_controller.rb
@@ -4,12 +4,25 @@ class Api::V0::Users::GamesController < ApplicationController
     admin_user = User.find(params[:id])
     game = Game.create(game_params)
     UserGame.create(user_id: admin_user.id, game_id: game.id, invitation: 3)
+    missing_accounts = []
+    params[:invitees].each do |email|
+      invitee = User.find_by(email: email)
+      if invitee
+        UserGame.create(user_id: invitee.id, game_id: game.id)
+      else
+        missing_accounts << email
+        InviteMailer.with(invitee: email, admin: admin_user.username).invite_email.deliver_now
+      end
+    end
+    unless missing_accounts.empty?
+      AdminNotifierMailer.with(admin: admin_user.email, game_name: game.name, missing_accounts: missing_accounts ).notify_email.deliver_now
+    end
     render json: GameSerializer.new(game)
   end
 
   private
 
   def game_params
-    params.permit(:length_in_days, :guess_lead_time, :player_cap)
+    params.permit(:length_in_days, :guess_lead_time, :player_cap, :name)
   end
 end

--- a/app/controllers/api/v0/users/votes_controller.rb
+++ b/app/controllers/api/v0/users/votes_controller.rb
@@ -1,3 +1,0 @@
-class Api::V0::Users::VotesController < ApplicationController
-
-end

--- a/app/mailers/admin_notifier_mailer.rb
+++ b/app/mailers/admin_notifier_mailer.rb
@@ -1,0 +1,10 @@
+class AdminNotifierMailer < ApplicationMailer
+  
+  def notify_email
+    @admin = params[:admin]
+    @game_name = params[:game_name]
+    @missing_accounts = params[:missing_accounts]
+
+    mail(to: @admin, subject: 'Weather Together - Game invitees without account')
+  end
+end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,0 +1,9 @@
+class InviteMailer < ApplicationMailer
+  
+  def invite_email
+    @invitee = params[:invitee]
+    @admin = params[:admin]
+
+    mail(to: @invitee, subject: 'You have been invited to play Weather Together')
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,13 @@
 class Game < ApplicationRecord
+  before_save do
+    unless self.start_date
+      self.start_date = self.find_start_date
+    end
+    unless self.close_date
+      self.close_date = self.find_close_date
+    end
+  end
+
   has_many :rounds
   has_many :user_games
   has_many :users, through: :user_games
@@ -8,5 +17,13 @@ class Game < ApplicationRecord
 
   def self.current_community_round
     Game.find_by(game_type: 0).rounds.order(close_date: :desc).first
+  end
+
+  def find_start_date
+    (Date.today + 1).to_s
+  end
+
+  def find_close_date
+    (Date.today + length_in_days + 1).to_s
   end
 end

--- a/app/models/user_game.rb
+++ b/app/models/user_game.rb
@@ -3,7 +3,7 @@ class UserGame < ApplicationRecord
   belongs_to :game
   has_many :rounds, through: :game
 
-  enum invitation: { sent: 0, accepted: 1, declined: 2 }
+  enum invitation: { sent: 0, accepted: 1, declined: 2, admin: 3 }
 
 
 end

--- a/app/models/user_game.rb
+++ b/app/models/user_game.rb
@@ -3,5 +3,7 @@ class UserGame < ApplicationRecord
   belongs_to :game
   has_many :rounds, through: :game
 
+  enum invitation: { sent: 0, accepted: 1, declined: 2 }
+
 
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -7,6 +7,7 @@ class GameSerializer
               :player_cap,
               :status,
               :start_date,
+              :close_date,
               :users
 
   attribute :users do |game|

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,6 +1,7 @@
 class GameSerializer
   include JSONAPI::Serializer
   attributes  :game_type,
+              :name,
               :length_in_days,
               :guess_lead_time,
               :player_cap,

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,0 +1,24 @@
+class GameSerializer
+  include JSONAPI::Serializer
+  attributes  :game_type,
+              :length_in_days,
+              :guess_lead_time,
+              :player_cap,
+              :status,
+              :start_date,
+              :users
+
+  attribute :users do |game|
+    game.users.map do |user|
+      {
+        id: user.id,
+        type: "user",
+        attributes: {
+          email: user.email,
+          username: user.username
+        }
+      }
+    end
+  end
+
+end

--- a/app/views/admin_notifier_mailer/notify_email.html.erb
+++ b/app/views/admin_notifier_mailer/notify_email.html.erb
@@ -1,0 +1,7 @@
+<h1>Thank you for creating the "<%= @game_name %>" custom game on Weather Together!</h1>
+<p>At least one person you invited to play does not yet have account on Weather Together. Their emails are below</p>
+<%= @missing_accounts.join(", \n") %>
+<br>
+<p>After they have made an account, you can reinvite them to your game.</p><br>
+<p>Thank you for playing!</p>
+<h3>The Weather Together Team</h3>

--- a/app/views/invite_mailer/invite_email.html.erb
+++ b/app/views/invite_mailer/invite_email.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @admin %> has invited you to play Weather Together!</h1>
+<p>Click the following link to see how to play:</p>
+<%= link_to 'Weather Together', "https://weather-together.onrender.com" %>
+
+<p>After you've created an account, ask <%= @admin %> to re-invite you to their custom game</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,16 +22,21 @@ Rails.application.routes.draw do
   get "api/v0/turnover", to: 'api/v0/cron#turnover'
   get "api/v0/turnover_confirm", to: 'api/v0/cron#turnover_confirm'
 
+  #rounds and voting
   get 'api/v0/rounds/:id/votes', to: 'api/v0/rounds/votes#index'
   get 'api/v0/rounds/most_recent/results', to: 'api/v0/rounds/votes#results'
   get 'api/v0/rounds/:id/results', to: 'api/v0/rounds/votes#results'
   get 'api/v0/users/:user_id/rounds/current_community_round', to: 'api/v0/users/rounds#current_community_round'
   post 'api/v0/users/:user_id/rounds/:round_id/votes/new', to: 'api/v0/rounds/votes#create'
   
+  #login
   get 'api/v0/users/:id/verify_account/:token', to: 'api/v0/users#verify_account', as: :verify_account
   post 'api/v0/users/login', to: 'api/v0/users#login', as: :login
   get 'api/v0/verification_sent', to: 'api/v0/users#verification_sent', as: :verification_sent
   post 'api/v0/users/oauth_login', to: 'api/v0/users#find_or_create'
+
+  #private/custom games
+  post 'api/v0/users/:id/games', to: 'api/v0/users/games#create'
 
 
 

--- a/db/migrate/20240201234209_add_invitationto_user_games.rb
+++ b/db/migrate/20240201234209_add_invitationto_user_games.rb
@@ -1,0 +1,6 @@
+class AddInvitationtoUserGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_games, :invitation, :integer
+    change_column_default :user_games, :invitation, 0
+  end
+end

--- a/db/migrate/20240202021514_add_default_to_games_game_type.rb
+++ b/db/migrate/20240202021514_add_default_to_games_game_type.rb
@@ -1,0 +1,5 @@
+class AddDefaultToGamesGameType < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :games, :game_type, 1
+  end
+end

--- a/db/migrate/20240202025006_add_start_date_and_close_date_to_game.rb
+++ b/db/migrate/20240202025006_add_start_date_and_close_date_to_game.rb
@@ -1,0 +1,6 @@
+class AddStartDateAndCloseDateToGame < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :start_date, :string
+    add_column :games, :close_date, :string
+  end
+end

--- a/db/migrate/20240202044730_add_name_to_games.rb
+++ b/db/migrate/20240202044730_add_name_to_games.rb
@@ -1,0 +1,5 @@
+class AddNameToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_02_021514) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_025006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_02_021514) do
     t.string "results"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "start_date"
+    t.string "close_date"
   end
 
   create_table "rounds", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_11_200956) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_021514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "games", force: :cascade do |t|
-    t.integer "game_type"
+    t.integer "game_type", default: 1
     t.integer "length_in_days"
     t.integer "guess_lead_time"
     t.integer "player_cap"
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_200956) do
     t.bigint "game_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "invitation", default: 0
     t.index ["game_id"], name: "index_user_games_on_game_id"
     t.index ["user_id"], name: "index_user_games_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_02_025006) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_044730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_02_025006) do
     t.datetime "updated_at", null: false
     t.string "start_date"
     t.string "close_date"
+    t.string "name"
   end
 
   create_table "rounds", force: :cascade do |t|

--- a/spec/requests/api/v0/users/games/create_spec.rb
+++ b/spec/requests/api/v0/users/games/create_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "users/games create" do
+  it "current_community_round", :vcr do
+    # test_data
+    # load_location_coordinates
+    @user1 = User.create!(username: "username1", email: "user1@gmail.com", password: "password1")
+
+    new_game = {
+      "length_in_days": 145,
+      "guess_lead_time": 12,
+      "player_cap": 12,
+      "invitees": ["email4@gmail.com", "email2@gmail.com",
+                  "email3@gmail.com"]
+      }
+    post "/api/v0/users/#{@user1.id}/games" , params: new_game.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    game = JSON.parse(response.body, symbolize_names: true)[:data]
+  end
+end

--- a/spec/requests/api/v0/users/games/create_spec.rb
+++ b/spec/requests/api/v0/users/games/create_spec.rb
@@ -5,12 +5,14 @@ describe "users/games create" do
     # test_data
     # load_location_coordinates
     @user1 = User.create!(username: "username1", email: "user1@gmail.com", password: "password1")
+    @user2 = User.create!(username: "username2", email: "user2@gmail.com", password: "password1")
 
     new_game = {
+      "name": "Storm Chasers",
       "length_in_days": 145,
       "guess_lead_time": 12,
       "player_cap": 12,
-      "invitees": ["email4@gmail.com", "email2@gmail.com",
+      "invitees": ["email4@gmail.com", "user2@gmail.com",
                   "email3@gmail.com"]
       }
     post "/api/v0/users/#{@user1.id}/games" , params: new_game.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
@@ -18,5 +20,28 @@ describe "users/games create" do
     expect(response.status).to eq(200)
 
     game = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(game).to be_a Hash
+    expect(game[:id].to_i).to_not eq(0)
+    expect(game[:type]).to eq("game")
+    expect(game[:attributes]).to be_a Hash
+    expect(game[:attributes][:game_type]).to eq("custom")
+    expect(game[:attributes][:name]).to eq("Storm Chasers")
+    expect(game[:attributes][:length_in_days]).to eq(145)
+    expect(game[:attributes][:guess_lead_time]).to eq(12)
+    expect(game[:attributes][:player_cap]).to eq(12)
+    expect(game[:attributes][:status]).to eq("open")
+    expect(game[:attributes][:start_date]).to be_a String
+    expect(game[:attributes][:close_date]).to be_a String
+
+    expect(game[:attributes][:users]).to be_an Array
+    expect(game[:attributes][:users].count).to eq(2)
+    expect(game[:attributes][:users].first).to be_a Hash
+    expect(game[:attributes][:users].first[:id]).to be_a Integer
+    expect(game[:attributes][:users].first[:type]).to eq("user")
+    expect(game[:attributes][:users].first[:attributes][:email]).to eq("user1@gmail.com")
+    expect(game[:attributes][:users].first[:attributes][:username]).to eq("username1")
+
+
   end
 end


### PR DESCRIPTION
## Description

The main purpose of this pull request is to implement the custom game creation endpoint. We cannot currently add people who do not have accounts, however, an email to join weather together is sent to any email address without an account, and an email is sent to the custom game admin telling them that they will have to re-add those people once they make an account.

NEXT: Invite to a created game, accept an invite

## Type of change

- [ ] fix
- [x] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!