### PR TITLE
FIX redis config to ENV

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,8 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: Rails.application.credentials.redis[:url] }
+  config.redis = { url: ENV['REDIS_URL'] }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: Rails.application.credentials.redis[:url] }
+  config.redis = { url: ENV['REDIS_URL'] }
 end
 


### PR DESCRIPTION
## Description
Heroku plugin `Heroku Data for Redis` would occasionally update the `REDIS_URL`, meaning this could not be statically stored in credentials. Attempt to bypass this issue by:

1. Update initializer `sidekiq.rb` to use ENV, `url: ENV['REDIS_URL']`
2. Update url, by running this command in the Heroku CLI, `heroku config:get REDIS_URL -a powerful-sierra-25067`

## Type of change

- [x] fix
- [ ] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [ ] code has been self reviewed
- [ ] code runs without any errors
- [ ] thorough testing has been implemented if adding feature
- [ ] all tests pass

### Thanks!